### PR TITLE
feat: Create Go SPA with Prometheus metrics and Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+Dockerfile
+.dockerignore
+.git
+.gitignore
+README.md
+*.md
+go.mod
+go.sum
+# Any local build artifacts if not covered by .gitignore
+main
+prometheus-app

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when run with the
+# -o option
+*.out
+
+# Go workspace file
+go.work
+
+# Local build
+main
+prometheus-app

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,19 +14,27 @@ RUN go mod download
 COPY . .
 
 # Build the Go app
-# -o /app/main specifies the output file path and name
-# . specifies that the main package is in the current directory
-RUN go build -o /app/main .
+# CGO_ENABLED=0 disables Cgo
+# GOOS=linux ensures the binary is built for Linux
+# -a installs the packages dependencies
+# -ldflags="-w -s" reduces the binary size by stripping debug information
+RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags="-w -s" -o /app/main .
 
-# Use a smaller, non-developer image for the final stage
-FROM alpine:latest
+# Use a specific version of alpine for the final stage
+FROM alpine:3.19
 
 # Set the working directory for the final image
 WORKDIR /app
 
-# Copy the built executable from the builder stage
-COPY --from=builder /app/main .
-COPY index.html .
+# Create a non-root user and group
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+# Copy the built executable and index.html from the builder stage, and set ownership
+COPY --from=builder --chown=appuser:appgroup /app/main .
+COPY --chown=appuser:appgroup index.html .
+
+# Switch to non-root user
+USER appuser
 
 # Expose port 8080 to the outside world
 EXPOSE 8080


### PR DESCRIPTION
This commit introduces a single-page Go application that serves an HTML page and exposes page visit metrics to Prometheus.

Key features and files:
- main.go: Core application logic, web server, and Prometheus metric (page_visits_total).
- index.html: Simple HTML page served by the application.
- Dockerfile: Multi-stage Dockerfile for building a minimal, secure image.
  - Uses specific base image versions (golang:1.21-alpine for build, alpine:3.19 for final).
  - Employs optimized Go build flags for a smaller, static binary.
  - Runs the application as a non-root user (appuser).
- docker-compose.yml: For easy local deployment of the application and a Prometheus server.
- prometheus.yml: Basic Prometheus configuration to scrape metrics from the application.
- README.md: Detailed instructions for local build, Docker build, and Docker Compose setup, including how to verify metrics in Prometheus.
- .gitignore: Standard Go and OS ignores.
- .dockerignore: Optimizes Docker build context.

The application listens on port 8080, serving the HTML page on `/` and Prometheus metrics on `/metrics`. The `page_visits_total` counter increments on each access to the root path.