### PR TITLE
Fix: Correct Docker build context in docker-compose.yml

### DIFF
--- a/app/docker/docker-compose.yml
+++ b/app/docker/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3.8'
 
 services:
   app:
-    build: .
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
     container_name: go-prometheus-app
     ports:
       - "8080:8080"


### PR DESCRIPTION
The docker-compose.yml located in app/docker/ was configured to use the app/docker/ directory as the build context by default. However, the Dockerfile expects source files (go.mod, src/, etc.) to be at the root of the build context, and these files are located in the parent app/ directory.

This commit modifies app/docker/docker-compose.yml to explicitly set the build context to '..' (the app/ directory) and specifies the Dockerfile location as 'docker/Dockerfile' relative to this new context.

This allows `docker-compose build` to successfully build the image when run from the app/docker/ directory.