### PR TITLE
Fix: Correct paths in Dockerfile for build context

### DIFF
--- a/app/docker/Dockerfile
+++ b/app/docker/Dockerfile
@@ -5,19 +5,19 @@ FROM golang:1.22-alpine AS builder
 WORKDIR /app
 
 # Copy go mod and sum files
-COPY go.mod go.sum ./
+COPY ../go.mod ../go.sum ./
 
 # Download dependencies
 RUN go mod download
 
 # Copy the local package source code
 # Copy only the src directory which contains main.go and index.html
-COPY src/ ./src/
+COPY ../src/ ./src/
 
 # Build the Go app
 # -o /app/main specifies the output file path and name
 # ./src/main.go specifies the entrypoint
-RUN go build -o /app/main ./src/main.go
+RUN go build -o /app/main ../src/main.go
 
 # Use a smaller, non-developer image for the final stage
 FROM alpine:latest


### PR DESCRIPTION
The Docker build was failing because the build context was set to `app/docker` in the GitHub Actions workflow, but the `COPY` instructions in the Dockerfile were expecting files and directories (go.mod, go.sum, src/) to be at the root of the build context.

This commit updates the paths in the Dockerfile to correctly reference these files and directories using `../` to navigate up one level from the `app/docker` context. Specifically:
- `COPY go.mod go.sum ./` changed to `COPY ../go.mod ../go.sum ./`
- `COPY src/ ./src/` changed to `COPY ../src/ ./src/`
- `RUN go build -o /app/main ./src/main.go` changed to `RUN go build -o /app/main ../src/main.go`