### PR TITLE
Fix: Adjust Docker build context and paths for robust build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -38,7 +38,8 @@ jobs:
       - name: Build and push with version tag
         uses: docker/build-push-action@v5
         with:
-          context: ./app/docker
+          context: ./app
+          file: ./app/docker/Dockerfile
           push: true
           tags: |
             ${{ secrets.DOCKER_HUB_USERNAME }}/mytestapp:${{ steps.bump-version.outputs.new_tag }}

--- a/app/docker/Dockerfile
+++ b/app/docker/Dockerfile
@@ -5,19 +5,19 @@ FROM golang:1.22-alpine AS builder
 WORKDIR /app
 
 # Copy go mod and sum files
-COPY ../go.mod ../go.sum ./
+COPY go.mod go.sum ./
 
 # Download dependencies
 RUN go mod download
 
 # Copy the local package source code
 # Copy only the src directory which contains main.go and index.html
-COPY ../src/ ./src/
+COPY src/ ./src/
 
 # Build the Go app
 # -o /app/main specifies the output file path and name
 # ./src/main.go specifies the entrypoint
-RUN go build -o /app/main ../src/main.go
+RUN go build -o /app/main ./src/main.go
 
 # Use a smaller, non-developer image for the final stage
 FROM alpine:latest


### PR DESCRIPTION
Resolves an issue where Docker builds were failing with a "/src: not found" error during cache key computation.

Changes made:
1. Changed the Docker build context in the GitHub Actions workflow (`.github/workflows/docker-image.yml`) from `./app/docker` to `./app`. This makes the `app` directory the root for Docker's build operations.

2. Specified the Dockerfile location in the workflow using `file: ./app/docker/Dockerfile`, as it's no longer at the root of the build context.

3. Updated paths in `app/docker/Dockerfile`:
    - `COPY` instructions for `go.mod`, `go.sum`, and `src/` now use paths directly relative to the new `./app` context (e.g., `COPY src/ ./src/`).
    - Corrected the `go build` command's source path to be `./src/main.go`, which is relative to the `WORKDIR /app` set inside the container.

This approach simplifies pathing within the Dockerfile and aims to provide a more standard and reliable build process by aligning the context more closely with your project structure.