### PR TITLE
Fix: Correct version bumping logic in GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Bump version
         id: bump-version
         run: |    
-          IFS='.' read -r MAJOR MINOR PATCH <<< "${LAST_TAG#v}"
+          LAST_TAG_VALUE="${{ steps.get-tag.outputs.last_tag }}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "${LAST_TAG_VALUE#v}"
           NEW_PATCH=$((PATCH + 1))
           NEW_TAG="v$MAJOR.$MINOR.$NEW_PATCH"
           echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The "Bump version" step was attempting to use a shell variable `LAST_TAG` which was not in its scope, as it was defined in a previous step's shell session. This resulted in `LAST_TAG` being treated as empty, leading to an invalid tag like "v..1" being generated.

This commit modifies the "Bump version" script to correctly consume the output "last_tag" from the "Get last tag" step using the syntax `${{ steps.get-tag.outputs.last_tag }}`. This ensures that the actual last tag (or the default "v0.0.0") is used for version calculation, preventing the generation of invalid tag names.